### PR TITLE
Modify tests to load the local development version of the plugin.

### DIFF
--- a/test/es6-native/karma.conf.js
+++ b/test/es6-native/karma.conf.js
@@ -1,7 +1,17 @@
 const path = require("path");
+const instrumenter = require("../..");
 
 module.exports = function(config) {
     config.set({
+
+        // This plugin configuration is required to run the instrumenter's test
+        // suite. If you copy this example, you should remove the plugins entry
+        // and just install karma-coverage-istanbul-instrumenter. It will be
+        // picked up automatically by karma.
+        plugins: [
+            "karma-*",
+            instrumenter,
+        ],
 
         frameworks: ["jasmine"],
 

--- a/test/rollup/karma.conf.js
+++ b/test/rollup/karma.conf.js
@@ -1,7 +1,17 @@
 const path = require("path");
+const instrumenter = require("../..");
 
 module.exports = function(config) {
     config.set({
+
+        // This plugin configuration is required to run the instrumenter's test
+        // suite. If you copy this example, you should remove the plugins entry
+        // and just install karma-coverage-istanbul-instrumenter. It will be
+        // picked up automatically by karma.
+        plugins: [
+            "karma-*",
+            instrumenter,
+        ],
 
         frameworks: ["jasmine"],
 


### PR DESCRIPTION
Prior to this change, cloning the repository and doing `npm install` and then `npm test` fails. That's because the tests are unable to find the plugin.

This PR modifies the tests so that they load the local development version of the plugin.