### PR TITLE
Allow processing inline sourcemaps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ root=true
 [**]
 indent_style = space
 indent_size = 4
+
+[**/package.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bundle.*
 coverage
 node_modules
 package-lock.json
+test/**/build

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "scripts": {
     "setup": "npm link && npm link karma-coverage-istanbul-instrumenter",
     "lint": "eslint ./src",
-    "test": "npm run test:build && karma start test/es6-native/karma.conf.js && karma start test/rollup/karma.conf.js",
-    "test:build": "cd test/rollup && rollup --config rollup.config.js && cd ../.."
+    "test": "npm run test:build && karma start test/es6-native/karma.conf.js && karma start test/rollup/karma.conf.js && karma start test/inline-sourcemap/karma.conf.js",
+    "test:build": "npm run test:build:rollup && npm run test:build:inline-sourcemap",
+    "test:build:rollup": "cd test/rollup && rollup --config rollup.config.js && cd ../..",
+    "test:build:inline-sourcemap": "cd test/inline-sourcemap && tsc",
+    "clean": "rm -rf test/*/build"
   },
   "repository": {
     "type": "git",
@@ -46,7 +49,8 @@
     "karma-coverage-istanbul-reporter": "^2.0.4",
     "karma-jasmine": "^2.0.1",
     "rollup": "^1.1.2",
-    "rollup-plugin-babel": "^4.3.2"
+    "rollup-plugin-babel": "^4.3.2",
+    "typescript": "^3.3.3333"
   },
   "peerDependencies": {
     "karma": "3 || 4"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "scripts": {
     "setup": "npm link && npm link karma-coverage-istanbul-instrumenter",
     "lint": "eslint ./src",
-    "test": "npm run test:build && karma start test/es6-native/karma.conf.js && karma start test/rollup/karma.conf.js && karma start test/inline-sourcemap/karma.conf.js",
-    "test:build": "npm run test:build:rollup && npm run test:build:inline-sourcemap",
+    "test": "npm run test:build && karma start test/es6-native/karma.conf.js && karma start test/rollup/karma.conf.js && karma start test/inline-sourcemap/karma.conf.js && karma start test/external-sourcemap/karma.conf.js",
+    "test:build": "npm run test:build:rollup && npm run test:build:inline-sourcemap && npm run test:build:external-sourcemap",
     "test:build:rollup": "cd test/rollup && rollup --config rollup.config.js && cd ../..",
     "test:build:inline-sourcemap": "cd test/inline-sourcemap && tsc",
+    "test:build:external-sourcemap": "cd test/external-sourcemap && tsc",
     "clean": "rm -rf test/*/build"
   },
   "repository": {

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -11,7 +11,10 @@ const createPreprocessor = (logger, config) => {
 
         log.debug("Processing \"%s\".", file.originalPath);
 
-        const converter = convertSourceMap.fromMapFileSource(content, path.dirname(file.originalPath));
+        let sourceMap = convertSourceMap.fromSource(content);
+        if(!sourceMap) {
+            sourceMap = convertSourceMap.fromMapFileSource(content, path.dirname(file.originalPath));
+        }
 
         instrumenter.instrument(content, file.originalPath, (error, instrumentedSource) => {
             if(error) {
@@ -21,7 +24,7 @@ const createPreprocessor = (logger, config) => {
             else {
                 done(instrumentedSource);
             }
-        }, converter ? converter.toObject() : undefined);
+        }, sourceMap ? sourceMap.sourcemap : undefined);
     };
 };
 

--- a/test/external-sourcemap/karma.conf.js
+++ b/test/external-sourcemap/karma.conf.js
@@ -1,0 +1,42 @@
+const path = require("path");
+const instrumenter = require("../..");
+
+module.exports = function(config) {
+    config.set({
+
+        // This plugin configuration is required to run the instrumenter's test
+        // suite. If you copy this example, you should remove the plugins entry
+        // and just install karma-coverage-istanbul-instrumenter. It will be
+        // picked up automatically by karma.
+        plugins: [
+            "karma-*",
+            instrumenter,
+        ],
+
+        frameworks: ["jasmine"],
+
+        files: [
+            { pattern: "./build/**/*.js", type: "module" },
+            { pattern: "./test/*.spec.js", type: "module" },
+        ],
+
+        preprocessors: {
+            "./build/**/!(*.spec).js": ["karma-coverage-istanbul-instrumenter"]
+        },
+
+        reporters: ["progress", "coverage-istanbul"],
+
+        coverageIstanbulInstrumenter: {
+            esModules: true,
+        },
+
+        coverageIstanbulReporter: {
+            reports: ["html"],
+            dir: path.join(__dirname, "coverage"),
+        },
+
+        browsers: ["ChromeHeadless"],
+
+        singleRun: true
+    });
+};

--- a/test/external-sourcemap/src/main.ts
+++ b/test/external-sourcemap/src/main.ts
@@ -1,0 +1,2 @@
+
+export const someVar = "someValue";

--- a/test/external-sourcemap/test/main.spec.js
+++ b/test/external-sourcemap/test/main.spec.js
@@ -1,0 +1,5 @@
+import { someVar } from "../build/main.js";
+
+it("works", () => {
+    expect(someVar).toBe("someValue");
+});

--- a/test/external-sourcemap/tsconfig.json
+++ b/test/external-sourcemap/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "build",
+        "module": "es6",
+        "target": "es6",
+        "sourceMap": true,
+        "inlineSources": true
+    }
+}

--- a/test/inline-sourcemap/karma.conf.js
+++ b/test/inline-sourcemap/karma.conf.js
@@ -1,0 +1,42 @@
+const path = require("path");
+const instrumenter = require("../..");
+
+module.exports = function(config) {
+    config.set({
+
+        // This plugin configuration is required to run the instrumenter's test
+        // suite. If you copy this example, you should remove the plugins entry
+        // and just install karma-coverage-istanbul-instrumenter. It will be
+        // picked up automatically by karma.
+        plugins: [
+            "karma-*",
+            instrumenter,
+        ],
+
+        frameworks: ["jasmine"],
+
+        files: [
+            { pattern: "./build/**/*.js", type: "module" },
+            { pattern: "./test/*.spec.js", type: "module" },
+        ],
+
+        preprocessors: {
+            "./build/**/!(*.spec).js": ["karma-coverage-istanbul-instrumenter"]
+        },
+
+        reporters: ["progress", "coverage-istanbul"],
+
+        coverageIstanbulInstrumenter: {
+            esModules: true,
+        },
+
+        coverageIstanbulReporter: {
+            reports: ["html"],
+            dir: path.join(__dirname, "coverage"),
+        },
+
+        browsers: ["ChromeHeadless"],
+
+        singleRun: true
+    });
+};

--- a/test/inline-sourcemap/src/main.ts
+++ b/test/inline-sourcemap/src/main.ts
@@ -1,0 +1,2 @@
+
+export const someVar = "someValue";

--- a/test/inline-sourcemap/test/main.spec.js
+++ b/test/inline-sourcemap/test/main.spec.js
@@ -1,0 +1,5 @@
+import { someVar } from "../build/main.js";
+
+it("works", () => {
+    expect(someVar).toBe("someValue");
+});

--- a/test/inline-sourcemap/tsconfig.json
+++ b/test/inline-sourcemap/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "build",
+        "module": "es6",
+        "target": "es6",
+        "inlineSources": true,
+        "inlineSourceMap": true
+    }
+}


### PR DESCRIPTION
As soon as I started editing `package.json` I ran into indentation problems and realized that I should have given it a separate rule, hence the first commit in this PR.

The 2nd commit adds a test that causes the instrumenter to run on files that have inline sourcemaps. If you run the tests without the 3rd commit, the new test will fail with an error message like this:

```
Error: ENOENT: no such file or directory, open '/home/ldd/src/git-repos/karma-coverage-istanbul-instrumenter/test/inline-sourcemap/build/data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFpbi5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9tYWluLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNBLE1BQU0sQ0FBQyxNQUFNLE9BQU8sR0FBRyxXQUFXLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyJcbmV4cG9ydCBjb25zdCBzb21lVmFyID0gXCJzb21lVmFsdWVcIjtcbiJdfQ==
```

`convert-source-map` tried to open a file by taking the `sourceMappingURL` as if it were a file name. :open_mouth: 
